### PR TITLE
Apply server-set options to all requests

### DIFF
--- a/lib/rocket_chat/server.rb
+++ b/lib/rocket_chat/server.rb
@@ -45,5 +45,9 @@ module RocketChat
       )
       Session.new self, Token.new(response['data'])
     end
+
+    def request_json(path, options = {})
+      super(path, @options.merge(options))
+    end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe RocketChat::Server do
   let(:server) { RocketChat::Server.new(SERVER_URI) }
+  let(:server_with_opts) { RocketChat::Server.new(SERVER_URI, headers: { 'X_TEST' => '1' }) }
 
   describe '#info' do
     before do
@@ -15,11 +16,30 @@ describe RocketChat::Server do
         }.to_json,
         status: 200
       )
+
+      stub_request(:get, SERVER_URI + '/api/v1/info')
+        .with(headers: { 'X_TEST' => '1' })
+        .to_return(
+          body: {
+            status: :success,
+            info: {
+              version: '0.6'
+            }
+          }.to_json,
+          status: 200
+        )
     end
 
     it 'gets server info' do
       info = server.info
       expect(info.version).to eq '0.5'
+    end
+
+    context 'with headers' do
+      it 'gets server info' do
+        info = server_with_opts.info
+        expect(info.version).to eq '0.6'
+      end
     end
   end
 


### PR DESCRIPTION
They were just stored but not used.

Example usage: a self-generated SSL certificate in development needing `ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE`