### PR TITLE
Add debugging option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,16 @@ session = rocket_server.login('username', 'password')
 session.logout
 ```
 
+#### debugging
+To debug the communications between the gem and Rocket.Chat, there is a debug option.
+It accepts a stream for logging.
+
+```ruby
+require 'rocketchat'
+
+rocket_server = RocketChat::Server.new('http://your.server.address/', debug: $stderr)
+```
+
 
 For details of specific APIs:
 

--- a/lib/rocket_chat/request_helper.rb
+++ b/lib/rocket_chat/request_helper.rb
@@ -29,6 +29,7 @@ module RocketChat
       check_response response, fail_unless_ok
 
       response_json = JSON.parse(response.body)
+      options[:debug].puts("Response: #{response_json.inspect}") if options[:debug]
       check_response_json response_json, upstreamed_errors
 
       response_json
@@ -79,6 +80,7 @@ module RocketChat
 
     def create_http(options)
       http = Net::HTTP.new(server.host, server.port)
+      http.set_debug_output(options[:debug]) if options[:debug]
 
       if server.scheme == 'https'
         http.use_ssl = true


### PR DESCRIPTION
This makes developing against a local Rocket.Chat easier, as you can also test that the messages being sent and received have the correct format.