### PR TITLE
Response parse improvements

### DIFF
--- a/lib/rocket_chat/error.rb
+++ b/lib/rocket_chat/error.rb
@@ -2,5 +2,6 @@ module RocketChat
   class Error < StandardError; end
   class HTTPError < Error; end
   class InvalidMethodError < HTTPError; end
+  class JsonParseError < Error; end
   class StatusError < Error; end
 end

--- a/lib/rocket_chat/request_helper.rb
+++ b/lib/rocket_chat/request_helper.rb
@@ -54,7 +54,7 @@ module RocketChat
     end
 
     def check_response(response, fail_unless_ok)
-      return unless fail_unless_ok && !response.is_a?(Net::HTTPOK)
+      return if response.is_a?(Net::HTTPOK) || !(fail_unless_ok || response.is_a?(Net::HTTPServerError))
       raise RocketChat::HTTPError, "Invalid http response code: #{response.code}"
     end
 

--- a/lib/rocket_chat/request_helper.rb
+++ b/lib/rocket_chat/request_helper.rb
@@ -28,7 +28,7 @@ module RocketChat
       response = request path, options
       check_response response, fail_unless_ok
 
-      response_json = JSON.parse(response.body)
+      response_json = parse_response(response.body)
       options[:debug].puts("Response: #{response_json.inspect}") if options[:debug]
       check_response_json response_json, upstreamed_errors
 
@@ -46,6 +46,12 @@ module RocketChat
     end
 
     private
+
+    def parse_response(response)
+      JSON.parse(response)
+    rescue JSON::ParserError
+      raise RocketChat::JsonParseError, "RocketChat response parse error: #{response}"
+    end
 
     def check_response(response, fail_unless_ok)
       return unless fail_unless_ok && !response.is_a?(Net::HTTPOK)


### PR DESCRIPTION
Especially the ServerError part is useful for when the proxy (Nginx, AWS ALB, etc) responds with 5xx.