### PR TITLE
feat: Channel and Group #kick APIs

### DIFF
--- a/lib/rocket_chat/messages/channel.rb
+++ b/lib/rocket_chat/messages/channel.rb
@@ -25,6 +25,21 @@ module RocketChat
       end
 
       #
+      # channels.kick REST API
+      # @param [String] room_id Rocket.Chat room id
+      # @param [String] user_id Rocket.Chat user id
+      # @return [Boolean]
+      # @raise [HTTPError, StatusError]
+      #
+      def kick(room_id: nil, user_id: nil)
+        session.request_json(
+          '/api/v1/channels.kick',
+          method: :post,
+          body: room_params(room_id, nil).merge(user_params(user_id, nil))
+        )['success']
+      end
+
+      #
       # channels.list REST API
       # @param [Integer] offset Query offset
       # @param [Integer] count Query count/limit

--- a/lib/rocket_chat/messages/group.rb
+++ b/lib/rocket_chat/messages/group.rb
@@ -40,6 +40,21 @@ module RocketChat
         )['success']
       end
 
+      #
+      # groups.kick REST API
+      # @param [String] room_id Rocket.Chat room id
+      # @param [String] user_id Rocket.Chat user id
+      # @return [Boolean]
+      # @raise [HTTPError, StatusError]
+      #
+      def kick(room_id: nil, user_id: nil)
+        session.request_json(
+          '/api/v1/groups.kick',
+          method: :post,
+          body: room_params(room_id, nil).merge(user_params(user_id, nil))
+        )['success']
+      end
+
       # groups.list REST API
       # @param [Integer] offset Query offset
       # @param [Integer] count Query count/limit

--- a/spec/rocket_chat/messages/group_spec.rb
+++ b/spec/rocket_chat/messages/group_spec.rb
@@ -312,4 +312,51 @@ describe RocketChat::Messages::Group do
       end
     end
   end
+
+  describe '#kick' do
+    before do
+      # Stubs for /api/v1/groups.kick REST API
+      stub_unauthed_request :post, '/api/v1/groups.kick'
+
+      stub_authed_request(:post, '/api/v1/groups.kick')
+        .to_return(not_provided_room_body)
+
+      stub_authed_request(:post, '/api/v1/groups.kick')
+        .with(
+          body: { roomId: 'missing-room', userId: '1' }
+        ).to_return(invalid_room_body)
+
+      stub_authed_request(:post, '/api/v1/groups.kick')
+        .with(
+          body: { roomId: 'a-room', userId: '1' }
+        ).to_return(
+          body: { success: true }.to_json,
+          status: 200
+        )
+    end
+
+    context 'with a valid session' do
+      it 'returns success' do
+        expect(scope.kick(room_id: 'a-room', user_id: '1')).to be_truthy
+      end
+
+      context 'with a missing room' do
+        it 'raises a status error' do
+          expect do
+            scope.kick(room_id: 'missing-room', user_id: '1')
+          end.to raise_error RocketChat::StatusError, invalid_room_message
+        end
+      end
+    end
+
+    context 'with an invalid session token' do
+      let(:token) { RocketChat::Token.new(authToken: nil, roomId: nil) }
+
+      it 'raises a status error' do
+        expect do
+          scope.kick(room_id: 'a-room', user_id: 'test')
+        end.to raise_error RocketChat::StatusError, 'You must be logged in to do this.'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added:

- [Channel Kick API](https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/channels-endpoints/kick)
- [Group Kick API](https://developer.rocket.chat/reference/api/rest-api/endpoints/core-endpoints/groups-endpoints/kick)

- Specs are passing
- Rubocop is passing

@abrom Since both API's do not allow `user#username` and `room#name`, I'm sending it as `nil` on `user_params` and `room_params` respectively.

