### PR TITLE
Add content-type and filename params for file upload

### DIFF
--- a/docs/channels.md
+++ b/docs/channels.md
@@ -193,6 +193,6 @@ require 'rocketchat'
 
 rocket_server = RocketChat::Server.new('http://your.server.address/')
 session = rocket_server.login('username', 'password')
-session.channels.upload_file(room_id: 'GENERAL', file: File, msg: "Optional Message", description: "Optional Description", tmid: "Optional thread message id")
+session.channels.upload_file(room_id: 'GENERAL', file: File, filename: "Optional. The name of the file to use.", content_type: "Optional. The content type of the uploaded file", msg: "Optional Message", description: "Optional Description", tmid: "Optional thread message id")
 
 ```

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -81,6 +81,6 @@ require 'rocketchat'
 
 rocket_server = RocketChat::Server.new('http://your.server.address/')
 session = rocket_server.login('username', 'password')
-session.groups.upload_file(room_id: 'GENERAL', file: File, msg: "Optional Message", description: "Optional Description", tmid: "Optional thread message id")
+session.groups.upload_file(room_id: 'GENERAL', file: File, filename: "Optional. The name of the file to use.", content_type: "Optional. The content type of the uploaded file", msg: "Optional Message", description: "Optional Description", tmid: "Optional thread message id")
 
 ```

--- a/lib/rocket_chat/messages/room.rb
+++ b/lib/rocket_chat/messages/room.rb
@@ -319,7 +319,7 @@ module RocketChat
         response = session.request_json(
           "#{API_PREFIX}/rooms.upload/#{room_id}",
           method: :post,
-          form_data: file_upload_hash(file: file, **rest_params)
+          form_data: file_upload_array(file: file, **rest_params)
         )
 
         RocketChat::Message.new response['message'] if response['success']
@@ -345,16 +345,16 @@ module RocketChat
           self.class.settable_attributes.include?(attribute)
       end
 
-      def file_upload_hash(**params)
+      def file_upload_array(**params)
         permited_keys_for_file_upload = %i[file msg description tmid]
-        hash = Util.slice_hash(params, *permited_keys_for_file_upload)
+        hash = Util.slice_hash(params, *permited_keys_for_file_upload).compact
 
         # NOTE: https://www.rubydoc.info/github/ruby/ruby/Net/HTTPHeader:set_form
         file_options = params.slice(:filename, :content_type).compact
         hash.map do |key, value|
-          next [key, value, file_options] if key == :file && file_options.keys.any?
+          next [key.to_s, value, file_options] if key == :file && file_options.keys.any?
 
-          [key, value]
+          [key.to_s, value]
         end
       end
     end

--- a/lib/rocket_chat/messages/room.rb
+++ b/lib/rocket_chat/messages/room.rb
@@ -354,7 +354,7 @@ module RocketChat
         hash.map do |key, value|
           next [key, value, file_options] if key == :file && file_options.keys.any?
 
-          [key, value] 
+          [key, value]
         end
       end
     end

--- a/lib/rocket_chat/messages/room.rb
+++ b/lib/rocket_chat/messages/room.rb
@@ -352,9 +352,9 @@ module RocketChat
         # NOTE: https://www.rubydoc.info/github/ruby/ruby/Net/HTTPHeader:set_form
         file_options = params.slice(:filename, :content_type).compact
         hash.map do |key, value|
-          next [key, value] unless key == :file && file_options.keys.any?
+          next [key, value, file_options] if key == :file && file_options.keys.any?
 
-          [key, value, file_options]
+          [key, value] 
         end
       end
     end

--- a/lib/rocket_chat/messages/room.rb
+++ b/lib/rocket_chat/messages/room.rb
@@ -347,7 +347,15 @@ module RocketChat
 
       def file_upload_hash(**params)
         permited_keys_for_file_upload = %i[file msg description tmid]
-        Util.slice_hash(params, *permited_keys_for_file_upload)
+        hash = Util.slice_hash(params, *permited_keys_for_file_upload)
+
+        # NOTE: https://www.rubydoc.info/github/ruby/ruby/Net/HTTPHeader:set_form
+        file_options = params.slice(:filename, :content_type).compact
+        hash.map do |key, value|
+          next [key, value] unless key == :file && file_options.keys.any?
+
+          [key, value, file_options]
+        end
       end
     end
   end

--- a/lib/rocket_chat/messages/room.rb
+++ b/lib/rocket_chat/messages/room.rb
@@ -349,7 +349,7 @@ module RocketChat
         permited_keys_for_file_upload = %i[file msg description tmid]
         hash = Util.slice_hash(params, *permited_keys_for_file_upload).compact
 
-        # NOTE: https://www.rubydoc.info/github/ruby/ruby/Net/HTTPHeader:set_form
+        # NOTE: https://docs.ruby-lang.org/en/master/Net/HTTPHeader.html#method-i-set_form
         file_options = params.slice(:filename, :content_type).compact
         hash.map do |key, value|
           next [key.to_s, value, file_options] if key == :file && file_options.keys.any?

--- a/lib/rocket_chat/request_helper.rb
+++ b/lib/rocket_chat/request_helper.rb
@@ -110,7 +110,7 @@ module RocketChat
         req = Net::HTTP::Post.new(path, headers)
         add_body(req, body) if body
 
-        form_data = reject_nils(options[:form_data])
+        form_data = options[:form_data]
         add_form_data(req, form_data) if form_data
       else
         uri = path
@@ -131,7 +131,6 @@ module RocketChat
     end
 
     def add_form_data(request, form_data)
-      form_data = form_data.transform_keys(&:to_s) if form_data.is_a? Hash
       request.set_form(form_data, 'multipart/form-data')
     end
 

--- a/spec/shared/room_behaviors.rb
+++ b/spec/shared/room_behaviors.rb
@@ -724,6 +724,21 @@ shared_examples 'room_behavior' do |room_type: nil, query: false|
       it { expect(upload).to be_a(RocketChat::Message) }
     end
 
+    context 'with content_type params' do
+      subject(:upload) { scope.upload_file(room_id: room_id, file: file, content_type: content_type, **rest_params) }
+
+      let(:content_type) { 'image/png' }
+      let(:file) { File.open('spec/fixtures/files/image.png') }
+      let(:response) { png_upload_response(room_id: room_id) }
+
+      before do
+        stub_authed_request(:post, path).to_return(body: response, status: 200)
+      end
+
+      it { expect { upload }.not_to raise_error }
+      it { expect(upload).to be_a(RocketChat::Message) }
+    end
+
     context 'when not accepted error is raised' do
       before do
         stub_authed_request(:post, path).to_return(body: response, status: 400)


### PR DESCRIPTION
Currently all files are sent with type `application/octet-stream`. This update will add ability to pass content_type and filename as args if needed

**Actual:**
<img width="450" alt="image" src="https://github.com/abrom/rocketchat-ruby/assets/38328305/ef98aacb-e509-4b7e-9851-6ffe958e0928">

```
{
    "message": {
      ...
        "file": {
            ...
            "type": "application/octet-stream"
        },
```

**Expected:**
<img width="420" alt="image" src="https://github.com/abrom/rocketchat-ruby/assets/38328305/4d3140ca-35d1-4543-b004-40120d7bfebc">

```
{
    "message": {
      ...
        "file": {
            ...
            "type": "image/jpeg"
        },
```