### PR TITLE
Fix deprecation in `User#info` fetching of user rooms

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
   - rubocop-rspec

--- a/lib/rocket_chat/messages/group.rb
+++ b/lib/rocket_chat/messages/group.rb
@@ -48,10 +48,10 @@ module RocketChat
       # @return [Room[]]
       # @raise [HTTPError, StatusError]
       #
-      def list(offset: nil, count: nil, sort: nil, fields: nil, query: nil)
+      def list(offset: nil, count: nil, sort: nil, fields: nil)
         response = session.request_json(
           '/api/v1/groups.list',
-          body: build_list_body(offset, count, sort, fields, query)
+          body: build_list_body(offset, count, sort, fields)
         )
 
         response['groups'].map { |hash| RocketChat::Room.new hash } if response['success']

--- a/lib/rocket_chat/messages/user.rb
+++ b/lib/rocket_chat/messages/user.rb
@@ -122,8 +122,7 @@ module RocketChat
       def info(user_id: nil, username: nil, include_rooms: false)
         response = session.request_json(
           '/api/v1/users.info',
-          body: user_params(user_id, username)
-            .merge(include_rooms ? { fields: { userRooms: 1 }.to_json } : {}),
+          body: user_params(user_id, username).merge(include_rooms ? { includeUserRooms: true } : {}),
           upstreamed_errors: ['error-invalid-user']
         )
 

--- a/spec/rocket_chat/messages/user_spec.rb
+++ b/spec/rocket_chat/messages/user_spec.rb
@@ -172,7 +172,7 @@ describe RocketChat::Messages::User do
       stub_authed_request(:get, '/api/v1/users.info?username=some_user')
         .to_return(expected)
 
-      stub_authed_request(:get, '/api/v1/users.info?fields=%7B%22userRooms%22:1%7D&username=some_user')
+      stub_authed_request(:get, '/api/v1/users.info?includeUserRooms=true&username=some_user')
         .to_return(
           body: {
             success: true,


### PR DESCRIPTION
- Relates to https://github.com/RocketChat/Rocket.Chat/pull/33622

Removed deprecated `Group#list` query parameter (should use `Group#list_all` if query is required)